### PR TITLE
Change back flatcar-cloudinit to coreos-cloudinit

### DIFF
--- a/build
+++ b/build
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-NAME_FLATCAR="flatcar-cloudinit"
 NAME="coreos-cloudinit"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
@@ -15,4 +14,4 @@ fi
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
-go build -ldflags "${GLDFLAGS}" -o ${GOBIN}/${NAME_FLATCAR} ${REPO_PATH}
+go build -ldflags "${GLDFLAGS}" -o ${GOBIN}/${NAME} ${REPO_PATH}

--- a/units/system-cloudinit@.service
+++ b/units/system-cloudinit@.service
@@ -9,4 +9,4 @@ ConditionFileNotEmpty=%f
 Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
-ExecStart=/usr/bin/flatcar-cloudinit --from-file=%f
+ExecStart=/usr/bin/coreos-cloudinit --from-file=%f

--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -11,4 +11,4 @@ Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/flatcar-cloudinit --from-proc-cmdline
+ExecStart=/usr/bin/coreos-cloudinit --from-proc-cmdline

--- a/units/user-cloudinit@.service
+++ b/units/user-cloudinit@.service
@@ -11,4 +11,4 @@ Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/flatcar-cloudinit --from-file=%f
+ExecStart=/usr/bin/coreos-cloudinit --from-file=%f

--- a/units/user-config-ovfenv.service
+++ b/units/user-config-ovfenv.service
@@ -10,4 +10,4 @@ Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/flatcar-cloudinit --from-vmware-ovf-env=/media/ovfenv/ovf-env.xml
+ExecStart=/usr/bin/coreos-cloudinit --from-vmware-ovf-env=/media/ovfenv/ovf-env.xml

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -11,7 +11,7 @@ Before=user-config.target
 # here instead of in the oem service because the oem unit is not written
 # to disk until the OEM cloud config is evaluated and I want to make sure
 # systemd knows about the ordering as early as possible.
-# flatcar-cloudinit could implement a simple lock but that cannot be used
+# coreos-cloudinit could implement a simple lock but that cannot be used
 # until after the systemd dbus calls are made non-blocking.
 After=oem-cloudinit.service
 
@@ -20,4 +20,4 @@ Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/flatcar-cloudinit --from-configdrive=/media/configdrive
+ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configdrive

--- a/units/user-configvirtfs.service
+++ b/units/user-configvirtfs.service
@@ -9,4 +9,4 @@ Type=oneshot
 TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/flatcar-cloudinit --from-configdrive=/media/configvirtfs
+ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configvirtfs


### PR DESCRIPTION
There's no need to rename this since coreos-cloudinit is just the name of
the project.