### PR TITLE
Support coreos.* kernel command line parameters

### DIFF
--- a/units/media-configdrive.mount
+++ b/units/media-configdrive.mount
@@ -5,7 +5,9 @@ Before=user-configdrive.service
 # or any host that has it explicitly enabled and not explicitly disabled.
 ConditionVirtualization=|vm
 ConditionKernelCommandLine=|flatcar.configdrive=1
+ConditionKernelCommandLine=|coreos.configdrive=1
 ConditionKernelCommandLine=!flatcar.configdrive=0
+ConditionKernelCommandLine=!coreos.configdrive=0
 
 [Mount]
 What=LABEL=config-2

--- a/units/media-configvirtfs.mount
+++ b/units/media-configvirtfs.mount
@@ -5,7 +5,9 @@ Before=user-configvirtfs.service
 # or any host that has it explicitly enabled and not explicitly disabled.
 ConditionVirtualization=|vm
 ConditionKernelCommandLine=|flatcar.configdrive=1
+ConditionKernelCommandLine=|coreos.configdrive=1
 ConditionKernelCommandLine=!flatcar.configdrive=0
+ConditionKernelCommandLine=!coreos.configdrive=0
 
 # Support old style setup for now
 Wants=addon-run@media-configvirtfs.service addon-config@media-configvirtfs.service


### PR DESCRIPTION
For compatibility do also recognize the coreos. prefix
for kernel command line parameters.

Note: Create a PR for coreos-overlay after merging (and also pick that for Alpha and Edge when merged).