### PR TITLE
Support both guestinfo.ignition.config and guestinfo.coreos.config as data source

### DIFF
--- a/datasource/metadata/test/test.go
+++ b/datasource/metadata/test/test.go
@@ -32,7 +32,7 @@ func (t *HttpClient) GetRetry(url string) ([]byte, error) {
 	if val, ok := t.Resources[url]; ok {
 		return []byte(val), nil
 	} else {
-		return nil, pkg.ErrNotFound{fmt.Errorf("not found: %q", url)}
+		return nil, pkg.ErrNotFound{Err: fmt.Errorf("not found: %q", url)}
 	}
 }
 

--- a/datasource/vmware/vmware.go
+++ b/datasource/vmware/vmware.go
@@ -122,19 +122,32 @@ func (v vmware) FetchMetadata() (metadata datasource.Metadata, err error) {
 }
 
 func (v vmware) FetchUserdata() ([]byte, error) {
-	encoding, err := v.readConfig("coreos.config.data.encoding")
-	if err != nil {
-		return nil, err
+	var data string
+	var encoding string
+	var url string
+	var err error
+
+	data, err = v.readConfig("ignition.config.data")
+	if err == nil && data != "" {
+		encoding, err = v.readConfig("ignition.config.data.encoding")
+	} else {
+		data, err = v.readConfig("coreos.config.data")
+		if err == nil && data != "" {
+			encoding, err = v.readConfig("coreos.config.data.encoding")
+		}
 	}
 
-	data, err := v.readConfig("coreos.config.data")
 	if err != nil {
 		return nil, err
 	}
 
 	// Try to fallback to url if no explicit data
 	if data == "" {
-		url, err := v.readConfig("coreos.config.url")
+		url, err = v.readConfig("ignition.config.url")
+		if err != nil || url == "" {
+			url, err = v.readConfig("coreos.config.url")
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/datasource/vmware/vmware_test.go
+++ b/datasource/vmware/vmware_test.go
@@ -153,9 +153,20 @@ func TestFetchUserdata(t *testing.T) {
 			userdata:  "test config",
 		},
 		{
+			variables: map[string]string{"ignition.config.data": "test config"},
+			userdata:  "test config",
+		},
+		{
 			variables: map[string]string{
 				"coreos.config.data.encoding": "",
 				"coreos.config.data":          "test config",
+			},
+			userdata: "test config",
+		},
+		{
+			variables: map[string]string{
+				"ignition.config.data.encoding": "",
+				"ignition.config.data":          "test config",
 			},
 			userdata: "test config",
 		},
@@ -175,7 +186,15 @@ func TestFetchUserdata(t *testing.T) {
 		},
 		{
 			variables: map[string]string{
+				"ignition.config.data.encoding": "gzip+base64",
+				"ignition.config.data":          "H4sIABaoWlUAAytJLS5RSM7PS8tMBwCQiHNZCwAAAA==",
+			},
+			userdata: "test config",
+		},
+		{
+			variables: map[string]string{
 				"coreos.config.data.encoding": "test encoding",
+				"coreos.config.data":          "abc",
 			},
 			err: errors.New(`Unsupported encoding "test encoding"`),
 		},
@@ -188,6 +207,18 @@ func TestFetchUserdata(t *testing.T) {
 		{
 			variables: map[string]string{
 				"coreos.config.url": "http://bad.example.com",
+			},
+			err: errors.New("Not found"),
+		},
+		{
+			variables: map[string]string{
+				"ignition.config.url": "http://good.example.com",
+			},
+			userdata: "test config",
+		},
+		{
+			variables: map[string]string{
+				"ignition.config.url": "http://bad.example.com",
 			},
 			err: errors.New("Not found"),
 		},

--- a/network/debian_test.go
+++ b/network/debian_test.go
@@ -20,10 +20,10 @@ import (
 
 func TestFormatConfigs(t *testing.T) {
 	for in, n := range map[string]int{
-		"":                                                    0,
-		"line1\\\nis long":                                    1,
-		"#comment":                                            0,
-		"#comment\\\ncomment":                                 0,
+		"":                    0,
+		"line1\\\nis long":    1,
+		"#comment":            0,
+		"#comment\\\ncomment": 0,
 		"  #comment \\\n comment\nline 1\nline 2\\\n is long": 2,
 	} {
 		lines := formatConfig(in)

--- a/network/interface_test.go
+++ b/network/interface_test.go
@@ -363,7 +363,7 @@ func TestFilename(t *testing.T) {
 		{logicalInterface{name: "iface", hwaddr: net.HardwareAddr([]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab}), configDepth: 1}, "01-iface"},
 	} {
 		if tt.i.Filename() != tt.f {
-			t.Fatalf("bad filename (%q): got %q, want %q", tt.i, tt.i.Filename(), tt.f)
+			t.Fatalf("bad filename (%v): got %q, want %q", tt.i, tt.i.Filename(), tt.f)
 		}
 	}
 }


### PR DESCRIPTION
- vmware: Support guestinfo.ignition.config.* variables    
    The Ignition data and the cloud-config data resides at the same place.
    There was a name change from coreos.config to ignition.config in upstream
    Ignition. This means that if only ignition.config is used as guestinfo
    variable only Ignition configs are currently accepted while both should
    be supported.
    Support the ignition.config variables and fall back to coreos.config
    variables the same way Ignition does, so that the user or a provisioning
    tool does not need to care which config format is used in the guestinfo
    variable.
- Fix (unrelated) errors reported by ./test

# How to use

Set `guestinfo.ignition.config.*` variables in VMware and use the cloud-config format.

# Testing done

```
./test
```