### PR TITLE
docs: favor "maintenance" wording

### DIFF
--- a/Documentation/cloud-config-deprecated.md
+++ b/Documentation/cloud-config-deprecated.md
@@ -2,10 +2,10 @@
 
 ---
 
-**NOTE**: coreos-cloudinit is no longer under active development and has been superseded by [Ignition][ignition]. For more information about the recommended tools for provisioning Container Linux, refer to the [provisioning documentation][provisioning].
+**NOTE**: coreos-cloudinit is in maintenance-mode and has been superseded by [Ignition][ignition]. For more information about the recommended tools for provisioning Container Linux, refer to the [provisioning documentation][provisioning].
 
 [ignition]: https://github.com/coreos/ignition
-[provisioning]: https://github.com/coreos/docs/blob/master/os/provisioning.md
+[provisioning]: https://docs.flatcar-linux.org/os/provisioning/
 
 ---
 

--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -2,10 +2,10 @@
 
 ---
 
-**NOTE**: coreos-cloudinit is no longer under active development and has been superseded by [Ignition][ignition]. For more information about the recommended tools for provisioning Container Linux, refer to the [provisioning documentation][provisioning].
+**NOTE**: coreos-cloudinit is in maintenance-mode and has been superseded by [Ignition][ignition]. For more information about the recommended tools for provisioning Container Linux, refer to the [provisioning documentation][provisioning].
 
 [ignition]: https://github.com/coreos/ignition
-[provisioning]: https://github.com/coreos/docs/blob/master/os/provisioning.md
+[provisioning]: https://docs.flatcar-linux.org/os/provisioning/
 
 ---
 


### PR DESCRIPTION
Rather than "no longer under active development"

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>
