### PR TITLE
Update NOTE that project is still maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTE**: This project has been superseded by [Ignition][ignition] and is no longer under active development. Please direct all development efforts to Ignition.
+**NOTE**: This project overlaps in purpose with [Ignition][ignition] which is where most active development is taking place. However, the Flatcar Container Linux team also continues to support and maintain this project to maintain compatibility with cloudinit based environments.
 
 [ignition]: https://github.com/coreos/ignition
 


### PR DESCRIPTION
# Make it clear that cloudinit is not deprecated

Updated the NOTE sentence at the top of the file, to indicate the project is still actively supported and maintained.

# How to use

Read the README file.

# Testing done

Looked at the file in github editor.