### PR TITLE
network: Restore KeepConfiguration=dhcp-on-stop

### DIFF
--- a/network/interface.go
+++ b/network/interface.go
@@ -85,6 +85,7 @@ func (i *logicalInterface) Network() string {
 		}
 	case configMethodDHCP:
 		config += "DHCP=true\n"
+		config += "KeepConfiguration=dhcp-on-stop\n"
 	}
 
 	return config


### PR DESCRIPTION
The default behavior in systemd-networkd was changed in v244 from
keeping the IP addresses and routes on service stop to deconfiguring
them:
https://github.com/systemd/systemd/commit/800603524a7ab076d40450286ff7802a04289b7f
Deconfiguring means that on system shutdown the DHCP address is
properly released but also has the side effect that orphaned processes
not part of a systemd unit don't have network connectivity when they
get the broadcasted SIGTERM.
Restore the previous behavior and hope that DHCP servers recognize
the system again on reboot and hand out the same address don't have to
rely on the address release (which, anyway, is not sent for a crashing
system either).

Fixes https://github.com/flatcar-linux/Flatcar/issues/213

# How to use

Configure, e.g., a VMware instance with the guestinfo network variables to use DHCP.
Then check
```
systemctl stop systemd-networkd
ip a
```
to report the interface as configured with an IP address.

# Testing done

Ran kola tests on all platforms.