### PR TITLE
network: Enable the RAs to fix IPv6 address assignment

### DIFF
--- a/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
+++ b/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
@@ -1,0 +1,1 @@
+- network: Enable the ICMPv6 RAs to fix IPv6 address assignment ([PR#12](https://github.com/flatcar-linux/coreos-cloudinit/pull/12))

--- a/network/interface.go
+++ b/network/interface.go
@@ -86,6 +86,7 @@ func (i *logicalInterface) Network() string {
 	case configMethodDHCP:
 		config += "DHCP=true\n"
 		config += "KeepConfiguration=dhcp-on-stop\n"
+		config += "IPv6AcceptRA=true\n"
 	}
 
 	return config


### PR DESCRIPTION
The IPv6 address are currently not automatically assigned due to the absence
of the IPv6AcceptRA configuration.

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>