### PR TITLE
If IMDSv2 is available from EC2 metadata, use it automatically.

### DIFF
--- a/changelog/enhancement/2022-08-01-enable-imdsv2.md
+++ b/changelog/enhancement/2022-08-01-enable-imdsv2.md
@@ -1,0 +1,1 @@
+- Enable IMDSv2 on AWS for enhanced security.  Fixes https://github.com/flatcar-linux/Flatcar/issues/787.


### PR DESCRIPTION
# Use IMDSv2 if available.

AWS's IMDSv2 requires a token which you can fetch from the IMDS itself.  If it's available, we'll fetch it and use it - if it's not, we'll revert to the previous behavior.  This should be viable for both IMDSv1 and IMDSv2.

Little caveat: as it stands, if cloudinit runs for more than 6 hours, we'll wind up using an expired token.  At the cost of somewhat more complex code, I can fix that - let me know.

Fixes https://github.com/flatcar-linux/Flatcar/issues/787.

## How to use

Start any flatcar EC2 instance with only IMDSv2 enabled - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.  If cloudinit works, this patch works.  :)

## Testing done

This has been pretty tricky since I can't get go 1.6 installed and this no longer builds with modern go.  If you'd accept some patches to update to go 1.18, let me know - I'd be happy to add that in.  Otherwise, I'm hoping to use existing CI to test.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
